### PR TITLE
feature: adds options to set auth and acct ports

### DIFF
--- a/src/main/scala/com/ngenia/gatling/radius/client/RadiusClient.scala
+++ b/src/main/scala/com/ngenia/gatling/radius/client/RadiusClient.scala
@@ -25,6 +25,8 @@ object RadiusClient {
       radiusProtocol.host,
       radiusProtocol.sharedKey)
 
+    radiusProtocol.authPort.foreach(radiusClient.setAuthPort(_))
+    radiusProtocol.acctPort.foreach(radiusClient.setAcctPort(_))
     radiusClient.setSocketTimeout(radiusProtocol.replyTimeout)
 
     val response: (Option[RadiusPacket], (Status, Option[String])) =

--- a/src/main/scala/com/ngenia/gatling/radius/protocol/RadiusProtocol.scala
+++ b/src/main/scala/com/ngenia/gatling/radius/protocol/RadiusProtocol.scala
@@ -28,6 +28,8 @@ object RadiusProtocol {
 
 case class RadiusProtocol(
                            host: String,
+                           authPort: Option[Int],
+                           acctPort: Option[Int],
                            sharedKey: String,
                            replyTimeout: Int,
                          ) extends Protocol {

--- a/src/main/scala/com/ngenia/gatling/radius/protocol/RadiusProtocolBuilder.scala
+++ b/src/main/scala/com/ngenia/gatling/radius/protocol/RadiusProtocolBuilder.scala
@@ -8,17 +8,17 @@
 package com.ngenia.gatling.radius.protocol
 
 case object RadiusProtocolBuilderBase {
-  def host(host: String) = RadiusProtocolBuilderSharedKey(host)
+  def host(host: String, authPort: Option[Int] = None, acctPort: Option[Int] = None) = RadiusProtocolBuilderSharedKey(host, authPort, acctPort)
 }
 
-case class RadiusProtocolBuilderSharedKey(host: String) {
-  def sharedKey(sharedKey: String) = RadiusProtocolBuilderReplyTimeout(host, sharedKey)
+case class RadiusProtocolBuilderSharedKey(host: String, authPort: Option[Int], acctPort: Option[Int]) {
+  def sharedKey(sharedKey: String) = RadiusProtocolBuilderReplyTimeout(host, authPort, acctPort, sharedKey)
 }
 
-case class RadiusProtocolBuilderReplyTimeout(host: String, sharedKey: String) {
-  def replyTimeout(replyTimeout: Int) = RadiusProtocolBuilder(host, sharedKey, replyTimeout) // Step 2
+case class RadiusProtocolBuilderReplyTimeout(host: String, authPort: Option[Int], acctPort: Option[Int], sharedKey: String) {
+  def replyTimeout(replyTimeout: Int) = RadiusProtocolBuilder(host, authPort, acctPort, sharedKey, replyTimeout) // Step 2
 }
 
-case class RadiusProtocolBuilder(host: String, sharedKey: String, replyTimeout: Int) {
-  def build(): RadiusProtocol = new RadiusProtocol(host, sharedKey, replyTimeout)
+case class RadiusProtocolBuilder(host: String, authPort: Option[Int], acctPort: Option[Int], sharedKey: String, replyTimeout: Int) {
+  def build(): RadiusProtocol = new RadiusProtocol(host, authPort, acctPort, sharedKey, replyTimeout)
 }


### PR DESCRIPTION
Adds optional params for auth and acct port in RadiusProtocol model.
Sets auth and acct port in Radius client.

To ensure backward compatibility, the `RadiusProtocolBuilderBase`
object's `host` method encapsulates auth and acct port params.
These are optional params and set to None by default.
The `host` method can be renamed to something like `address` or
`hostAddress` in a major version release.